### PR TITLE
Updated Spawn Item window to have ComboBoxes for Infusions and Ashes of War

### DIFF
--- a/ItemSpawn.xaml
+++ b/ItemSpawn.xaml
@@ -28,7 +28,7 @@
             <TextBox Grid.Row="1" Grid.Column="0" x:Name="txtItem" TextChanged="txtItem_TextChanged"></TextBox>
             <Button Grid.Row="1" Grid.Column="1" Click="showList">?</Button>
             <TextBox Grid.Row="1" Grid.Column="2" x:Name="txtLevel">0</TextBox>
-            <TextBox Grid.Row="1" Grid.Column="3" x:Name="txtInfusion">Normal</TextBox>
+            <ComboBox Grid.Row="1" Grid.Column="3" x:Name="txtInfusion">Normal</ComboBox>
             <TextBox Grid.Row="1" Grid.Column="4" x:Name="txtAsh">Default</TextBox>
             <TextBox Grid.Row="1" Grid.Column="5" x:Name="txtQuantity">1</TextBox>
         </Grid>

--- a/ItemSpawn.xaml
+++ b/ItemSpawn.xaml
@@ -29,7 +29,7 @@
             <Button Grid.Row="1" Grid.Column="1" Click="showList">?</Button>
             <TextBox Grid.Row="1" Grid.Column="2" x:Name="txtLevel">0</TextBox>
             <ComboBox Grid.Row="1" Grid.Column="3" x:Name="txtInfusion">Normal</ComboBox>
-            <TextBox Grid.Row="1" Grid.Column="4" x:Name="txtAsh">Default</TextBox>
+            <ComboBox Grid.Row="1" Grid.Column="4" x:Name="txtAsh">Default</ComboBox>
             <TextBox Grid.Row="1" Grid.Column="5" x:Name="txtQuantity">1</TextBox>
         </Grid>
         <Button Click="spawnItem" x:Name="btnSpawn">Spawn</Button>

--- a/ItemSpawn.xaml.cs
+++ b/ItemSpawn.xaml.cs
@@ -10,6 +10,9 @@ namespace EldenRingTool
         {
             _process = process;
             InitializeComponent();
+            txtInfusion.Items.Clear();
+            txtInfusion.ItemsSource = ItemDB.Infusions.Select(x => x.Item1).ToList();
+            txtInfusion.SelectedIndex = 0;
             updateMatch();
         }
 

--- a/ItemSpawn.xaml.cs
+++ b/ItemSpawn.xaml.cs
@@ -13,6 +13,14 @@ namespace EldenRingTool
             txtInfusion.Items.Clear();
             txtInfusion.ItemsSource = ItemDB.Infusions.Select(x => x.Item1).ToList();
             txtInfusion.SelectedIndex = 0;
+
+            txtAsh.Items.Clear();
+            var ashesOfWar = ItemDB.Items.Where(x => x.Item1.Contains("Ash of War: ")) 
+                                             .Select(x => x.Item1.Replace("Ash of War: ", "")) // removes the repetitive "ash of war" text for display.
+                                             .ToList();
+            ashesOfWar.Insert(0, "Default");
+            txtAsh.ItemsSource = ashesOfWar;
+            txtAsh.SelectedIndex = 0;
             updateMatch();
         }
 
@@ -67,7 +75,6 @@ namespace EldenRingTool
                 txtInfusion.Text = infus.Item1;
                 uint itemID = item.Item2 + level + infus.Item2;
                 var ash = ItemDB.Ashes.Where(x => x.Item1.ToLower().Contains(txtAsh.Text.ToLower())).FirstOrDefault();
-                txtAsh.Text = ash.Item1;
                 uint qty;
                 if (!uint.TryParse(txtQuantity.Text, out qty)) { qty = 1; }
                 _process.spawnItem(itemID, qty, ash.Item2);


### PR DESCRIPTION
Instead of free-text for these values, it pulls from the ItemDB that we already have available. Should have the infusion/ash of war persist after spawning so that users can spawn multiple of the same item quickly, should they need to.