### PR TITLE
Stat editing page improvements

### DIFF
--- a/StatsEditor.xaml
+++ b/StatsEditor.xaml
@@ -6,15 +6,24 @@
         xmlns:local="clr-namespace:EldenRingTool"
         mc:Ignorable="d"
         Title="Stats Editor" Width="150" ResizeMode="NoResize" SizeToContent="Height" WindowStartupLocation="CenterOwner">
+    <Window.Resources>
+        <Style TargetType="TextBox">
+            <EventSetter Event="GotKeyboardFocus" Handler="TextBox_GotKeyboardFocus"/>
+        </Style>
+    </Window.Resources>
     <StackPanel Orientation="Vertical" x:Name="mainPanel">
         <StackPanel Orientation="Vertical" x:Name="statsPanel">
             <Grid x:Name="statsGrid">
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="3*"/>
+                    <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="2*"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <Label Grid.Row="0" Grid.Column="0" x:Name="lblExample">SomeStat</Label>
-                <TextBox Grid.Row="0" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" x:Name="txtExample">99</TextBox>
+                <Button Grid.Row="0" Grid.Column="1" Height="18" FontSize="10" Name="decreaseExample" KeyboardNavigation.IsTabStop="False">-</Button>
+                <TextBox Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" x:Name="txtExample" TextAlignment="Center">99</TextBox>
+                <Button Grid.Row="0" Grid.Column="3" Height="18" FontSize="10" Name="increaseExample" KeyboardNavigation.IsTabStop="False">+</Button>
             </Grid>
         </StackPanel>
         <Button Click="okClicked">OK</Button>

--- a/StatsEditor.xaml.cs
+++ b/StatsEditor.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace EldenRingTool
 {
@@ -9,6 +10,8 @@ namespace EldenRingTool
     {
         List<(string, int)> _stats;
         Action<List<(string, int)>> _callback = null;
+        List<Button> _decButtons = new List<Button>();
+        List<Button> _incButtons = new List<Button>();
         List<TextBox> _boxes = new List<TextBox>();
         public StatsEditor(List<(string, int)> stats, Action<List<(string, int)>> callback)
         {
@@ -25,14 +28,39 @@ namespace EldenRingTool
                 statsGrid.Children.Add(lbl);
                 Grid.SetRow(lbl, i);
                 Grid.SetColumn(lbl, 0);
+
                 var txt = new TextBox();
                 txt.HorizontalAlignment = HorizontalAlignment.Stretch;
                 txt.VerticalAlignment = VerticalAlignment.Center;
                 txt.Text = stats[i].Item2.ToString();
-                statsGrid.Children.Add(txt);
-                Grid.SetRow(txt, i);
-                Grid.SetColumn(txt, 1);
                 _boxes.Add(txt);
+
+                var decButton = new Button();
+                decButton.Height = 18;
+                decButton.HorizontalAlignment = HorizontalAlignment.Stretch;
+                decButton.IsTabStop = false;
+                decButton.Content = "-";
+                decButton.Click += (sender, e) => Button_DecreaseStat(txt);
+                _decButtons.Add(decButton);
+
+                var incButton = new Button();
+                incButton.Height = 18;
+                incButton.HorizontalAlignment = HorizontalAlignment.Stretch;
+                incButton.IsTabStop = false;
+                incButton.Content = "+";
+                incButton.Click += (sender, e) => Button_IncreaseStat(txt);
+                _incButtons.Add(incButton);
+
+                Grid.SetRow(decButton, i);
+                Grid.SetColumn(decButton, 1);
+                Grid.SetRow(txt, i);
+                Grid.SetColumn(txt, 2);
+                Grid.SetRow(incButton, i);
+                Grid.SetColumn(incButton, 3);
+
+                statsGrid.Children.Add(txt);
+                statsGrid.Children.Add(decButton);
+                statsGrid.Children.Add(incButton);
             }
         }
 
@@ -47,6 +75,26 @@ namespace EldenRingTool
             }
             _callback(_stats);
             Close();
+        }
+
+        private void TextBox_GotKeyboardFocus(object sender, RoutedEventArgs e)
+        {
+            TextBox tb = (TextBox)sender;
+            tb.Dispatcher.BeginInvoke(new Action(() => tb.SelectAll()));
+        }
+
+        private void Button_DecreaseStat(TextBox txt)
+        {
+            if (int.TryParse(txt.Text, out int value)) { 
+                txt.Text = (--value).ToString();
+            }
+        }
+
+        private void Button_IncreaseStat(TextBox txt)
+        {
+            if (int.TryParse(txt.Text, out int value)) { 
+                txt.Text = (++value).ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
Added + and - buttons to quickly change stats instead of having to manually type the value each time. 
Added an OnFocus event that highlights the text for the user when selected by clicking or tabbing. Saves time so they shouldn't have to select->backspace->type.

The only improvement I would have liked to have added to this is to do the calculation for the total Rune Level and adjust that value on the character automatically. Currently if you're RL1 and update all stats to 50, your Rune Level stays the same and the cost to level up stays as if it were RL1. It would be a nice QoL feature to determine what level the character is at and in turn update that value in-game so the rune costs can be accurately determined. 