### PR TITLE
Enemy Resistances + UI Cleanup + Auto-Launcher

### DIFF
--- a/ERProcess.cs
+++ b/ERProcess.cs
@@ -1369,6 +1369,38 @@ namespace EldenRingTool
             }
         }
 
+        public float getTargetDefenses(TargetInfo stat)
+        {
+            var targetPtr = (IntPtr)ReadUInt64(erBase + codeCavePtrLoc);
+            var ptr1 = (IntPtr)ReadUInt64(targetPtr + 0x58);
+            var ptr2 = (IntPtr)ReadUInt64(ptr1 + 0x18);
+            var ptr3 = (IntPtr)ReadUInt64(ptr2 + 0xC0);
+            var npcParamPtr = (IntPtr)ReadUInt64(ptr3 + 0x18); // 
+
+            switch (stat)
+            {
+                case TargetInfo.STANDARD:
+                    return ReadFloat(npcParamPtr + 0x1A4);
+                case TargetInfo.SLASH:
+                    return ReadFloat(npcParamPtr + 0x1A8);
+                case TargetInfo.STRIKE:
+                    return ReadFloat(npcParamPtr + 0x1AC);
+                case TargetInfo.PIERCE:
+                    return ReadFloat(npcParamPtr + 0x1B0);
+                case TargetInfo.MAGIC:
+                    return ReadFloat(npcParamPtr + 0x1B4);
+                case TargetInfo.FIRE:
+                    return ReadFloat(npcParamPtr + 0x1B8);
+                case TargetInfo.LIGHTNING:
+                    return ReadFloat(npcParamPtr + 0x1BC);
+                case TargetInfo.HOLY:
+                    return ReadFloat(npcParamPtr + 0x1C0);
+                default:
+                    return 0.0f;
+            }
+
+        }
+
         public double getSetTargetInfo(TargetInfo info, int? setVal = null)
         {//most are actually ints but it's easier just to use a common type. double can store fairly large ints exactly.
             double ret = double.NaN;

--- a/ERProcess.cs
+++ b/ERProcess.cs
@@ -321,6 +321,8 @@ namespace EldenRingTool
             FROST, FROST_MAX,
             SLEEP, SLEEP_MAX,
             MADNESS, MADNESS_MAX,
+            STANDARD, SLASH, STRIKE, PIERCE,
+            MAGIC, FIRE, LIGHTNING, HOLY,
         }
 
         const long SANE_MINIMUM = 0x700000000000;

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -195,7 +195,7 @@
                     <TextBlock x:Name="poiseTimerText" Margin="5,2" DockPanel.Dock="Left" Width="125">Poise reset time: 00.0</TextBlock>
                     <ProgressBar x:Name="poiseTimerBar" Height="20" Minimum="0" Maximum="1" Margin="2,2" />
                 </DockPanel>
-                <StackPanel x:Name="resistsPanel">
+                <StackPanel x:Name="resistsPanel" Visibility="Collapsed">
                     <DockPanel>
                         <TextBlock x:Name="poisonText" Margin="5,2" DockPanel.Dock="Left" Width="125" FontSize="10">Poison: 0000 / 0000</TextBlock>
                         <ProgressBar x:Name="poisonBar" Height="15" Minimum="0" Maximum="1" Margin="2,2" Foreground="#FF006D14" />
@@ -225,28 +225,42 @@
                         <ProgressBar x:Name="madBar" Height="15" Minimum="0" Maximum="1" Margin="2,2" Foreground="#FFB08306" />
                     </DockPanel>
                 </StackPanel>
-                <StackPanel x:Name="defensesPanel">
-                    <DockPanel>
-                        <TextBlock x:Name="slashText" Margin="5,0">Slash:</TextBlock>
-                        <TextBlock x:Name="slashVal"  Margin="5,0">xx%</TextBlock>
-                        <TextBlock x:Name="strikeText" Margin="5,0">Strike:</TextBlock>
-                        <TextBlock x:Name="strikeVal"  Margin="5,0">xx%</TextBlock>
-                        <TextBlock x:Name="pierceText" Margin="5,0">Pierce:</TextBlock>
-                        <TextBlock x:Name="pierceVal"  Margin="5,0">xx%</TextBlock>
-                        <TextBlock x:Name="standardText" Margin="5,0">Standard:</TextBlock>
-                        <TextBlock x:Name="standardVal"  Margin="5,0">xx%</TextBlock>
-                    </DockPanel>
-                    <DockPanel>
-                        <TextBlock x:Name="magicText" Margin="5,0">Magic:</TextBlock>
-                        <TextBlock x:Name="magicVal"  Margin="5,0">xx%</TextBlock>
-                        <TextBlock x:Name="fireText" Margin="5,0">Fire:</TextBlock>
-                        <TextBlock x:Name="fireVal"  Margin="5,0">xx%</TextBlock>
-                        <TextBlock x:Name="lightningText" Margin="5,0">Lightning:</TextBlock>
-                        <TextBlock x:Name="lightningVal"  Margin="5,0">xx%</TextBlock>
-                        <TextBlock x:Name="holyText" Margin="5,0">Holy:</TextBlock>
-                        <TextBlock x:Name="holyVal"  Margin="5,0">xx%</TextBlock>
-                    </DockPanel>
-                </StackPanel>
+                <Grid x:Name="defensesPanel">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="45px"/>   
+                        <ColumnDefinition Width="35px"/>   
+                        <ColumnDefinition Width="35px" />  
+                        <ColumnDefinition Width="30px"/>   
+                        <ColumnDefinition Width="40px"/>   
+                        <ColumnDefinition Width="35px"/>   
+                        <ColumnDefinition Width="60px" />     
+                        <ColumnDefinition Width="30px"/>   
+                    </Grid.ColumnDefinitions>
+
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    
+                    <TextBlock Grid.Row="0" Grid.Column="0" x:Name="strikeText" HorizontalAlignment="Left" Margin="5,0">Strike:</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="1" x:Name="strikeVal" Margin="2,0">xx%</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="2" x:Name="slashText" HorizontalAlignment="Left">Slash:</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="3" x:Name="slashVal" Margin="2,0">xx%</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="4" x:Name="pierceText" HorizontalAlignment="Left">Pierce:</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="5" x:Name="pierceVal" Margin="2,0">xx%</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="6" x:Name="standardText" HorizontalAlignment="Left">Standard:</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="7" x:Name="standardVal" Margin="2,0">xx%</TextBlock>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" x:Name="magicText" HorizontalAlignment="Left" Margin="5,0">Magic:</TextBlock>
+                    <TextBlock Grid.Row="1" Grid.Column="1" x:Name="magicVal" Margin="2,0">xx%</TextBlock>
+                    <TextBlock Grid.Row="1" Grid.Column="2" x:Name="fireText" HorizontalAlignment="Left">Fire:</TextBlock>
+                    <TextBlock Grid.Row="1" Grid.Column="3" x:Name="fireVal" Margin="2,0">xx%</TextBlock>
+                    <TextBlock Grid.Row="1" Grid.Column="4" x:Name="holyText" HorizontalAlignment="Left">Holy:</TextBlock>
+                    <TextBlock Grid.Row="1" Grid.Column="5" x:Name="holyVal" Margin="2,0">xx%</TextBlock>
+                    <TextBlock Grid.Row="1" Grid.Column="6" x:Name="lightningText" HorizontalAlignment="Left">Lightning:</TextBlock>
+                    <TextBlock Grid.Row="1" Grid.Column="7" x:Name="lightningVal" Margin="2,2">xx%</TextBlock>
+
+                </Grid>
                 <StackPanel Orientation="Horizontal" x:Name="freezeHPPanel">
                     <CheckBox Checked="targetHpFreezeOn" Unchecked="targetHpFreezeOff" Margin="1,2,0,2" x:Name="chkFreezeHP">Freeze HP</CheckBox>
                     <Button Click="killTarget" Margin="5,0">Kill</Button>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:EldenRingTool"
         mc:Ignorable="d"
-        Title="ERTool VERSION" Width="330" ResizeMode="NoResize" SizeToContent="Height"
+        Title="ERTool VERSION" Width="345" ResizeMode="NoResize" SizeToContent="Height"
         >
     <DockPanel Name="dockPanel">
         <StackPanel DockPanel.Dock="Top">
@@ -18,12 +18,12 @@
                     <StackPanel Orientation="Horizontal" Margin="0,0,8,0">
                         <CheckBox Checked="noDeathOn" Unchecked="noDeathOff" x:Name="chkPlayerNoDeath" Content="No Death" Margin="0,0,10,0"/>
                         <CheckBox Checked="oneHPOn" Unchecked="oneHPOff" x:Name="chkOneHP" Content="1 HP" Margin="0,0,10,0"/>
-                        <CheckBox Checked="maxHPOn" Unchecked="maxHPOff" Margin="0,0,10,0" x:Name="chkMaxHP" Content="Max HP"/>
-                        <CheckBox Checked="runeArcOn" Unchecked="runArcOff" x:Name="chkRuneArc" Content="Rune Arc" RenderTransformOrigin="2.863,-1.6"/>
+                        <CheckBox Checked="maxHPOn" Unchecked="maxHPOff" Margin="5,0,10,0" x:Name="chkMaxHP" Content="Max HP"/>
+                        <CheckBox Checked="runeArcOn" Unchecked="runArcOff" x:Name="chkRuneArc" Content="Rune Arc" Margin="22,0,0,0"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="noStamOn" Unchecked="noStamOff" x:Name="chkInfStam" Content="Inf Stam" Margin="0,0,10,0"/>
-                        <CheckBox Checked="noFPOn" Unchecked="noFPOff" Margin="0,0,10,0" x:Name="chkInfFP" Content="Inf FP"/>
+                        <CheckBox Checked="noFPOn" Unchecked="noFPOff" Margin="8,0,10,0" x:Name="chkInfFP" Content="Inf FP"/>
                         <CheckBox Checked="noGoodsOn" Unchecked="noGoodsOff" Margin="0,0,10,0" x:Name="chkInfConsum" Content="Inf Consum."/>
                         <CheckBox Checked="oneShotOn" Unchecked="oneShotOff" Margin="0,0,10,0" x:Name="chkOneShot" Content="One-Shot"/>
                     </StackPanel>
@@ -43,7 +43,7 @@
                 </DockPanel>
                 <StackPanel x:Name="TorrentPanel">
                     <StackPanel Orientation="Horizontal">
-                        <CheckBox Checked="torNoDeathOn" Unchecked="torNoDeathOff" Margin="0,0,5,0" x:Name="chkTorNoDeath" Content="No Death"/>
+                        <CheckBox Checked="torNoDeathOn" Unchecked="torNoDeathOff" Margin="0,0,10,0" x:Name="chkTorNoDeath" Content="No Death"/>
                         <CheckBox Checked="torrentAnywhereOn" Unchecked="torrentAnywhereOff" x:Name="chkTorrentAnywhere" Content="Torrent Anywhere"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
@@ -69,12 +69,12 @@
                 <StackPanel x:Name="MovementPanel">
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="noGravOn" Unchecked="noGravOff" x:Name="chkPlayerNoGrav" Content="No Gravity"/>
-                        <CheckBox Checked="noMapColOn" Unchecked="nomapColOff" Margin="5,0" x:Name="chkPlayerNoMapCol" Content="No Map Collision"/>
+                        <CheckBox Checked="noMapColOn" Unchecked="nomapColOff" Margin="15,0" x:Name="chkPlayerNoMapCol" Content="No Map Collision"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="freeCamOn" Unchecked="freeCamOff" x:Name="chkFreeCam" Content="Free Camera"/>
                         <CheckBox Checked="freeCamControlOn" Unchecked="freeCamControlOff" Margin="5,0" x:Name="chkFreeCamControl" Content="Player control"/>
-                        <CheckBox Checked="noClipOn" Unchecked="noClipOff" x:Name="chkNoClip" Content="No Clip"/>
+                        <CheckBox Checked="noClipOn" Unchecked="noClipOff" Margin="25,0" x:Name="chkNoClip" Content="No Clip"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
                         <Button Margin="1,0,5,0" Click="doYeet" Content="Forward" Height="20"/>
@@ -122,7 +122,7 @@
                 <StackPanel x:Name="MeshPanel">
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="charMeshOn" Unchecked="charMeshOff" x:Name="chkCharMesh" Content="Character Mesh"/>
-                        <CheckBox Checked="charModelHideOn" Unchecked="charModelHideOff" Margin="10,0" x:Name="chkHideModels" Content="Hide Models"/>
+                        <CheckBox Checked="charModelHideOn" Unchecked="charModelHideOff" Margin="15,0" x:Name="chkHideModels" Content="Hide Models"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="colMeshAOn" Unchecked="colMeshAOff" x:Name="chkColMeshA" Content="Collision Mesh A"/>
@@ -137,11 +137,11 @@
                 <StackPanel x:Name="ViewsPanel">
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="poiseViewOn" Unchecked="poiseViewOff" x:Name="chkPoiseView" Content="Poise View"/>
-                        <CheckBox Checked="targetingViewOn" Unchecked="targetingViewOff" x:Name="chkTargetingView" Content="Targeting View (laggy)" Margin="5,0,0,0"/>
+                        <CheckBox Checked="targetingViewOn" Unchecked="targetingViewOff" x:Name="chkTargetingView" Content="Targeting View (laggy)" Margin="15,0,0,0"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="eventDrawOn" Unchecked="eventDrawOff" x:Name="chkEventView" Content="Events View"/>
-                        <CheckBox Checked="soundViewOn" Unchecked="soundViewOff" x:Name="chkSoundView" Margin="5,0" Content="Sound View"/>
+                        <CheckBox Checked="soundViewOn" Unchecked="soundViewOff" x:Name="chkSoundView" Margin="8,0" Content="Sound View"/>
                     </StackPanel>
                 </StackPanel>
                 <DockPanel x:Name="MiscPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=MiscPanel}">
@@ -174,7 +174,7 @@
                 <StackPanel x:Name="QoLPanel">
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="steamInputEnumDisableOn" Unchecked="steamInputEnumDisableOff" x:Name="chkSteamInputEnum" Content="Stutter Fix"/>
-                        <CheckBox Checked="disableAchieveOn" Unchecked="disableAchieveOff" x:Name="chkSteamAchieve" Margin="5,0" Content="Disable Achievements (Freeze Fix)"/>
+                        <CheckBox Checked="disableAchieveOn" Unchecked="disableAchieveOff" x:Name="chkSteamAchieve" Margin="15,0" Content="Disable Achievements (Freeze Fix)"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Checked="muteMusic" Unchecked="unmuteMusic" x:Name="chkMuteMusic" Content="Mute Music"/>
@@ -251,14 +251,14 @@
                 <StackPanel x:Name="defensesPanel" Visibility="Collapsed">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="45px"/>   
-                            <ColumnDefinition Width="35px"/>   
+                            <ColumnDefinition Width="40px"/>   
+                            <ColumnDefinition Width="40px"/>   
                             <ColumnDefinition Width="35px" />  
                             <ColumnDefinition Width="40px"/>   
                             <ColumnDefinition Width="40px"/>   
-                            <ColumnDefinition Width="35px"/>   
-                            <ColumnDefinition Width="60px" />     
-                            <ColumnDefinition Width="30px"/>   
+                            <ColumnDefinition Width="40px"/>   
+                            <ColumnDefinition Width="55px" />     
+                            <ColumnDefinition Width="40px"/>   
                         </Grid.ColumnDefinitions>
 
                         <Grid.RowDefinitions>
@@ -266,7 +266,7 @@
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                     
-                        <TextBlock Grid.Row="0" Grid.Column="0" x:Name="strikeText" HorizontalAlignment="Left" Margin="5,0">Strike:</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="0" x:Name="strikeText" HorizontalAlignment="Left" Margin="2,0">Strike:</TextBlock>
                         <TextBlock Grid.Row="0" Grid.Column="1" x:Name="strikeVal" Margin="2,0">--</TextBlock>
                         <TextBlock Grid.Row="0" Grid.Column="2" x:Name="slashText" HorizontalAlignment="Left">Slash:</TextBlock>
                         <TextBlock Grid.Row="0" Grid.Column="3" x:Name="slashVal" Margin="2,0">--</TextBlock>
@@ -275,7 +275,7 @@
                         <TextBlock Grid.Row="0" Grid.Column="6" x:Name="standardText" HorizontalAlignment="Left">Standard:</TextBlock>
                         <TextBlock Grid.Row="0" Grid.Column="7" x:Name="standardVal" Margin="2,0">--</TextBlock>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" x:Name="magicText" HorizontalAlignment="Left" Margin="5,0">Magic:</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="0" x:Name="magicText" HorizontalAlignment="Left" Margin="2 ,0">Magic:</TextBlock>
                         <TextBlock Grid.Row="1" Grid.Column="1" x:Name="magicVal" Margin="2,0">--</TextBlock>
                         <TextBlock Grid.Row="1" Grid.Column="2" x:Name="fireText" HorizontalAlignment="Left">Fire:</TextBlock>
                         <TextBlock Grid.Row="1" Grid.Column="3" x:Name="fireVal" Margin="2,0">--</TextBlock>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -12,7 +12,7 @@
             <StackPanel x:Name="mainPanel">
                 <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=PlayerPanel}">
                     <TextBlock Text="Player ▼" Margin="2,0,2,0" FontWeight="Bold"/>
-                    <Separator Margin="0,5,0,0"/>
+                    <Button Width="15" DockPanel.Dock="Right" HorizontalAlignment="Right" Content="▼" Click="ToggleCollapse"></Button>
                 </DockPanel>
                 <StackPanel x:Name="PlayerPanel">
                     <StackPanel Orientation="Horizontal" Margin="0,0,8,0">

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -10,7 +10,7 @@
     <DockPanel Name="dockPanel">
         <StackPanel DockPanel.Dock="Top">
             <StackPanel x:Name="mainPanel">
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=PlayerPanel}">
+                <DockPanel x:Name="PlayerPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=PlayerPanel}">
                     <TextBlock Text="Player ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Button Width="15" DockPanel.Dock="Right" HorizontalAlignment="Right" Content="▼" Click="ToggleCollapse"></Button>
                 </DockPanel>
@@ -37,7 +37,7 @@
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=TorrentPanel}">
+                <DockPanel x:Name="TorrentPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=TorrentPanel}">
                     <TextBlock Text="Torrent ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -51,7 +51,7 @@
                         <CheckBox Checked="torNoMapColOn" Unchecked="torNomapColOff" Margin="5,0" x:Name="chkTorNoMapCol" Content="No Map Collision"/>
                     </StackPanel>
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=EnemyPanel}">
+                <DockPanel x:Name="EnemyPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=EnemyPanel}">
                     <TextBlock Text="Enemies ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -62,7 +62,7 @@
                         <CheckBox Checked="repeatActionOn" Unchecked="repeatActionOff" Margin="5,0" x:Name="chkRepeatAction" Content="Repeat Last Action"/>
                     </StackPanel>
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=MovementPanel}">
+                <DockPanel x:Name="MovementPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=MovementPanel}">
                     <TextBlock Text="Movement ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -87,7 +87,7 @@
                     </StackPanel>
                     <TextBlock FontSize="10" Margin="0,2,0,0"><Run Text="Hold ctrl/shift/alt to go further"/></TextBlock>
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=TeleportPanel}">
+                <DockPanel x:Name="TeleportPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=TeleportPanel}">
                     <TextBlock Text="Teleport ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -105,7 +105,7 @@
                         <TextBlock x:Name="globalPos"><Run Text="Global:"/></TextBlock>
                     </StackPanel>
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=HitboxPanel}">
+                <DockPanel x:Name="HitboxPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=HitboxPanel}">
                     <TextBlock Text="Hitboxes ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -115,7 +115,7 @@
                         <CheckBox Checked="hitboxBOn" Unchecked="hitboxBOff" Margin="10,0" x:Name="chkHitboxB" Content="View B"/>
                     </StackPanel>
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=MeshPanel}">
+                <DockPanel x:Name="MeshPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=MeshPanel}">
                     <TextBlock Text="Mesh Viewers ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -130,7 +130,7 @@
                         <Button Click="changeMeshColours" Content="Change Colours" FontSize="10"/>
                     </StackPanel>
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=ViewsPanel}">
+                <DockPanel x:Name="ViewsPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=ViewsPanel}">
                     <TextBlock Text="Views ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -144,7 +144,7 @@
                         <CheckBox Checked="soundViewOn" Unchecked="soundViewOff" x:Name="chkSoundView" Margin="5,0" Content="Sound View"/>
                     </StackPanel>
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=MiscPanel}">
+                <DockPanel x:Name="MiscPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=MiscPanel}">
                     <TextBlock Text="Misc ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -167,7 +167,7 @@
                         <Button Click="setClearCount" Margin="5,0,0,0" Content="NG+"/>
                     </StackPanel>
                 </StackPanel>
-                <DockPanel Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=QoLPanel}">
+                <DockPanel x:Name="QoLPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=QoLPanel}">
                     <TextBlock Text="QoL ▼" Margin="2,0,2,0" FontWeight="Bold"/>
                     <Separator Margin="0,5,0,0"/>
                 </DockPanel>
@@ -182,18 +182,37 @@
                 </StackPanel>
                 <Button Click="installTargetHook" Margin="0,5" x:Name="targetHookButton" Content="Enable target options"/>
             </StackPanel>
-            <StackPanel x:Name="targetPanel" IsEnabled="False" Opacity="0.5">
-                <DockPanel>
-                    <TextBlock x:Name="hpText" Margin="5,2" DockPanel.Dock="Left" Width="125">HP: 00000 / 00000</TextBlock>
-                    <ProgressBar x:Name="hpBar" Height="20" Minimum="0" Maximum="1" Margin="2,2" />
+            <StackPanel x:Name="targetPanel" IsEnabled="False" Opacity="0.5" Visibility="Collapsed">
+                <DockPanel x:Name="hpPoisePanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=hpPoisePanel}">
+                    <TextBlock Text="HP / Poise ▼" Margin="2,0,2,0" FontWeight="Bold"/>
+                    <Separator Margin="0,5,0,0"/>
                 </DockPanel>
-                <DockPanel>
-                    <TextBlock x:Name="poiseText" Margin="5,2" DockPanel.Dock="Left" Width="125">Poise: 000 / 000</TextBlock>
-                    <ProgressBar x:Name="poiseBar" Height="20" Minimum="0" Maximum="1" Margin="2,2"/>
-                </DockPanel>
-                <DockPanel>
-                    <TextBlock x:Name="poiseTimerText" Margin="5,2" DockPanel.Dock="Left" Width="125">Poise reset time: 00.0</TextBlock>
-                    <ProgressBar x:Name="poiseTimerBar" Height="20" Minimum="0" Maximum="1" Margin="2,2" />
+                <StackPanel x:Name="hpPoisePanel">
+                    <DockPanel>
+                        <TextBlock x:Name="hpText" Margin="5,2" DockPanel.Dock="Left" Width="125">HP: 00000 / 00000</TextBlock>
+                        <ProgressBar x:Name="hpBar" Height="20" Minimum="0" Maximum="1" Margin="2,2" />
+                    </DockPanel>
+                    <DockPanel>
+                        <TextBlock x:Name="poiseText" Margin="5,2" DockPanel.Dock="Left" Width="125">Poise: 000 / 000</TextBlock>
+                        <ProgressBar x:Name="poiseBar" Height="20" Minimum="0" Maximum="1" Margin="2,2"/>
+                    </DockPanel>
+                    <DockPanel>
+                        <TextBlock x:Name="poiseTimerText" Margin="5,2" DockPanel.Dock="Left" Width="125">Poise reset time: 00.0</TextBlock>
+                        <ProgressBar x:Name="poiseTimerBar" Height="20" Minimum="0" Maximum="1" Margin="2,2" />
+                    </DockPanel>
+                    <StackPanel Orientation="Horizontal" x:Name="freezeHPPanel">
+                        <CheckBox Checked="targetHpFreezeOn" Unchecked="targetHpFreezeOff" Margin="1,2,0,2" x:Name="chkFreezeHP">Freeze HP</CheckBox>
+                        <Button Click="killTarget" Margin="5,0">Kill</Button>
+                        <Button Click="setHP" Margin="2,0">25%</Button>
+                        <Button Click="setHP" Margin="2,0">50%</Button>
+                        <Button Click="setHP" Margin="2,0">75%</Button>
+                        <Button Click="setHP" Margin="2,0">100%</Button>
+                        <Button Click="setHPCustom" Margin="2,0">Custom</Button>
+                    </StackPanel>
+                </StackPanel>
+                <DockPanel x:Name="resistsPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=resistsPanel}">
+                    <TextBlock Text="Resists ▲" Margin="2,0,2,0" FontWeight="Bold"/>
+                    <Separator Margin="0,5,0,0"/>
                 </DockPanel>
                 <StackPanel x:Name="resistsPanel" Visibility="Collapsed">
                     <DockPanel>
@@ -225,50 +244,47 @@
                         <ProgressBar x:Name="madBar" Height="15" Minimum="0" Maximum="1" Margin="2,2" Foreground="#FFB08306" />
                     </DockPanel>
                 </StackPanel>
-                <Grid x:Name="defensesPanel">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="45px"/>   
-                        <ColumnDefinition Width="35px"/>   
-                        <ColumnDefinition Width="35px" />  
-                        <ColumnDefinition Width="30px"/>   
-                        <ColumnDefinition Width="40px"/>   
-                        <ColumnDefinition Width="35px"/>   
-                        <ColumnDefinition Width="60px" />     
-                        <ColumnDefinition Width="30px"/>   
-                    </Grid.ColumnDefinitions>
+                <DockPanel x:Name="defensesPanelControl" Height="16" MouseLeftButtonDown="dockPanel_MouseLeftButtonDown" Tag="{Binding ElementName=defensesPanel}">
+                    <TextBlock Text="Defenses ▲" Margin="2,0,2,0" FontWeight="Bold"/>
+                    <Separator Margin="0,5,0,0"/>
+                </DockPanel>
+                <StackPanel x:Name="defensesPanel" Visibility="Collapsed">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="45px"/>   
+                            <ColumnDefinition Width="35px"/>   
+                            <ColumnDefinition Width="35px" />  
+                            <ColumnDefinition Width="40px"/>   
+                            <ColumnDefinition Width="40px"/>   
+                            <ColumnDefinition Width="35px"/>   
+                            <ColumnDefinition Width="60px" />     
+                            <ColumnDefinition Width="30px"/>   
+                        </Grid.ColumnDefinitions>
 
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
                     
-                    <TextBlock Grid.Row="0" Grid.Column="0" x:Name="strikeText" HorizontalAlignment="Left" Margin="5,0">Strike:</TextBlock>
-                    <TextBlock Grid.Row="0" Grid.Column="1" x:Name="strikeVal" Margin="2,0">xx%</TextBlock>
-                    <TextBlock Grid.Row="0" Grid.Column="2" x:Name="slashText" HorizontalAlignment="Left">Slash:</TextBlock>
-                    <TextBlock Grid.Row="0" Grid.Column="3" x:Name="slashVal" Margin="2,0">xx%</TextBlock>
-                    <TextBlock Grid.Row="0" Grid.Column="4" x:Name="pierceText" HorizontalAlignment="Left">Pierce:</TextBlock>
-                    <TextBlock Grid.Row="0" Grid.Column="5" x:Name="pierceVal" Margin="2,0">xx%</TextBlock>
-                    <TextBlock Grid.Row="0" Grid.Column="6" x:Name="standardText" HorizontalAlignment="Left">Standard:</TextBlock>
-                    <TextBlock Grid.Row="0" Grid.Column="7" x:Name="standardVal" Margin="2,0">xx%</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="0" x:Name="strikeText" HorizontalAlignment="Left" Margin="5,0">Strike:</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="1" x:Name="strikeVal" Margin="2,0">--</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="2" x:Name="slashText" HorizontalAlignment="Left">Slash:</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="3" x:Name="slashVal" Margin="2,0">--</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="4" x:Name="pierceText" HorizontalAlignment="Left">Pierce:</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="5" x:Name="pierceVal" Margin="2,0">--</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="6" x:Name="standardText" HorizontalAlignment="Left">Standard:</TextBlock>
+                        <TextBlock Grid.Row="0" Grid.Column="7" x:Name="standardVal" Margin="2,0">--</TextBlock>
 
-                    <TextBlock Grid.Row="1" Grid.Column="0" x:Name="magicText" HorizontalAlignment="Left" Margin="5,0">Magic:</TextBlock>
-                    <TextBlock Grid.Row="1" Grid.Column="1" x:Name="magicVal" Margin="2,0">xx%</TextBlock>
-                    <TextBlock Grid.Row="1" Grid.Column="2" x:Name="fireText" HorizontalAlignment="Left">Fire:</TextBlock>
-                    <TextBlock Grid.Row="1" Grid.Column="3" x:Name="fireVal" Margin="2,0">xx%</TextBlock>
-                    <TextBlock Grid.Row="1" Grid.Column="4" x:Name="holyText" HorizontalAlignment="Left">Holy:</TextBlock>
-                    <TextBlock Grid.Row="1" Grid.Column="5" x:Name="holyVal" Margin="2,0">xx%</TextBlock>
-                    <TextBlock Grid.Row="1" Grid.Column="6" x:Name="lightningText" HorizontalAlignment="Left">Lightning:</TextBlock>
-                    <TextBlock Grid.Row="1" Grid.Column="7" x:Name="lightningVal" Margin="2,2">xx%</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="0" x:Name="magicText" HorizontalAlignment="Left" Margin="5,0">Magic:</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="1" x:Name="magicVal" Margin="2,0">--</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="2" x:Name="fireText" HorizontalAlignment="Left">Fire:</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="3" x:Name="fireVal" Margin="2,0">--</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="4" x:Name="holyText" HorizontalAlignment="Left">Holy:</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="5" x:Name="holyVal" Margin="2,0">--</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="6" x:Name="lightningText" HorizontalAlignment="Left">Lightning:</TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="7" x:Name="lightningVal" Margin="2,2">--</TextBlock>
 
-                </Grid>
-                <StackPanel Orientation="Horizontal" x:Name="freezeHPPanel">
-                    <CheckBox Checked="targetHpFreezeOn" Unchecked="targetHpFreezeOff" Margin="1,2,0,2" x:Name="chkFreezeHP">Freeze HP</CheckBox>
-                    <Button Click="killTarget" Margin="5,0">Kill</Button>
-                    <Button Click="setHP" Margin="2,0">25%</Button>
-                    <Button Click="setHP" Margin="2,0">50%</Button>
-                    <Button Click="setHP" Margin="2,0">75%</Button>
-                    <Button Click="setHP" Margin="2,0">100%</Button>
-                    <Button Click="setHPCustom" Margin="2,0">Custom</Button>
+                    </Grid>
                 </StackPanel>
             </StackPanel>
         </StackPanel>
@@ -281,8 +297,8 @@
             <StackPanel Orientation="Horizontal" Margin="0,0" x:Name="resizePanel">
                 <CheckBox Checked="stayOnTop" Unchecked="dontStayOnTop" FontSize="10" Margin="5,0" x:Name="chkStayOnTop">Stay on top</CheckBox>
                 <Button FontSize="10" Click="toggleStatsFull" x:Name="compactButton">Toggle Stats/Full</Button>
-                <Button FontSize="10" Click="toggleResists" x:Name="resistsToggle" Margin="5,0">Toggle Resists</Button>
-                <Button FontSize="10" Click="toggleCoords" x:Name="coordsToggle" Margin="0,0">Toggle Coords</Button>
+                <!--<Button FontSize="10" Click="toggleResists" x:Name="resistsToggle" Margin="5,0">Toggle Resists</Button>-->
+                <Button FontSize="10" Click="toggleCoords" x:Name="coordsToggle" Margin="5,0">Toggle Coords</Button>
             </StackPanel>
             <Button Click="doQuitout" Height="40" x:Name="quitoutButton">Instant Quitout</Button>
         </StackPanel>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -195,7 +195,7 @@
                     <TextBlock x:Name="poiseTimerText" Margin="5,2" DockPanel.Dock="Left" Width="125">Poise reset time: 00.0</TextBlock>
                     <ProgressBar x:Name="poiseTimerBar" Height="20" Minimum="0" Maximum="1" Margin="2,2" />
                 </DockPanel>
-                <StackPanel x:Name="resistsPanel" Visibility="Collapsed">
+                <StackPanel x:Name="resistsPanel">
                     <DockPanel>
                         <TextBlock x:Name="poisonText" Margin="5,2" DockPanel.Dock="Left" Width="125" FontSize="10">Poison: 0000 / 0000</TextBlock>
                         <ProgressBar x:Name="poisonBar" Height="15" Minimum="0" Maximum="1" Margin="2,2" Foreground="#FF006D14" />
@@ -223,6 +223,28 @@
                     <DockPanel>
                         <TextBlock x:Name="madText" Margin="5,2" DockPanel.Dock="Left" Width="125" FontSize="10">Madness: 0000 / 0000</TextBlock>
                         <ProgressBar x:Name="madBar" Height="15" Minimum="0" Maximum="1" Margin="2,2" Foreground="#FFB08306" />
+                    </DockPanel>
+                </StackPanel>
+                <StackPanel x:Name="defensesPanel">
+                    <DockPanel>
+                        <TextBlock x:Name="slashText" Margin="5,0">Slash:</TextBlock>
+                        <TextBlock x:Name="slashVal"  Margin="5,0">xx%</TextBlock>
+                        <TextBlock x:Name="strikeText" Margin="5,0">Strike:</TextBlock>
+                        <TextBlock x:Name="strikeVal"  Margin="5,0">xx%</TextBlock>
+                        <TextBlock x:Name="pierceText" Margin="5,0">Pierce:</TextBlock>
+                        <TextBlock x:Name="pierceVal"  Margin="5,0">xx%</TextBlock>
+                        <TextBlock x:Name="standardText" Margin="5,0">Standard:</TextBlock>
+                        <TextBlock x:Name="standardVal"  Margin="5,0">xx%</TextBlock>
+                    </DockPanel>
+                    <DockPanel>
+                        <TextBlock x:Name="magicText" Margin="5,0">Magic:</TextBlock>
+                        <TextBlock x:Name="magicVal"  Margin="5,0">xx%</TextBlock>
+                        <TextBlock x:Name="fireText" Margin="5,0">Fire:</TextBlock>
+                        <TextBlock x:Name="fireVal"  Margin="5,0">xx%</TextBlock>
+                        <TextBlock x:Name="lightningText" Margin="5,0">Lightning:</TextBlock>
+                        <TextBlock x:Name="lightningVal"  Margin="5,0">xx%</TextBlock>
+                        <TextBlock x:Name="holyText" Margin="5,0">Holy:</TextBlock>
+                        <TextBlock x:Name="holyVal"  Margin="5,0">xx%</TextBlock>
                     </DockPanel>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" x:Name="freezeHPPanel">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -676,7 +676,7 @@ namespace EldenRingTool
 
                 magicVal.Text = magicDefense + "%";
                 fireVal.Text = fireDefense + "%";
-                lightningVal.Text = fireDefense + "%";
+                lightningVal.Text = lightningDefense + "%";
                 holyVal.Text = holyDefense + "%";
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1731,19 +1731,10 @@ namespace EldenRingTool
 
             foreach (UIElement element in mainPanel.Children)
             {
-                if (element is StackPanel stackPanel && stackPanel.Name != null)
+                if (element is StackPanel stackPanel && stackPanel.Name != null && stackPanel.Visibility != newVisibility)
                 {
-                    // Toggle the visibility of each DockPanel
+                    dockPanel_MouseLeftButtonDown(stackPanel, null);
                     stackPanel.Visibility = newVisibility;
-                }
-                else if (element is DockPanel dockPanel) {
-                    var textBox = dockPanel.Children.OfType<TextBlock>().FirstOrDefault();
-                    if (textBox != null)
-                    {
-                        textBox.Text = newVisibility == Visibility.Visible ?
-                                                        textBox.Text.Substring(0, textBox.Text.Length - 1) + "▼" :
-                                                        textBox.Text.Substring(0, textBox.Text.Length - 1) + "▲";
-                    }
                 }
             }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -76,7 +76,7 @@ namespace EldenRingTool
             GAME_SPEED_25PC, GAME_SPEED_50PC, GAME_SPEED_75PC, GAME_SPEED_100PC, GAME_SPEED_150PC, GAME_SPEED_200PC, GAME_SPEED_300PC, GAME_SPEED_500PC, GAME_SPEED_1000PC,
             FPS_30, FPS_60, FPS_120, FPS_144, FPS_240, FPS_1000,
             FPS, //arbitrary fps
-            TOGGLE_STATS_FULL, TOGGLE_RESISTS, TOGGLE_COORDS,
+            TOGGLE_STATS_FULL, TOGGLE_RESISTS, TOGGLE_DEFENSES, TOGGLE_COORDS,
             ENABLE_TARGET_HOOK, STAY_ON_TOP,
             GREAT_RUNE, PHYSICK, ASHES, SPELLS,
         }
@@ -589,6 +589,7 @@ namespace EldenRingTool
                     break;
                 case HOTKEY_ACTIONS.TOGGLE_STATS_FULL: toggleStatsFull(null, null); break;
                 case HOTKEY_ACTIONS.TOGGLE_RESISTS: toggleResists(null, null); break;
+                case HOTKEY_ACTIONS.TOGGLE_DEFENSES: toggleDefenses(null, null); break;
                 case HOTKEY_ACTIONS.TOGGLE_COORDS: toggleCoords(null, null); break;
                 case HOTKEY_ACTIONS.ENABLE_TARGET_HOOK: installTargetHook(targetHookButton, null); break;
                 case HOTKEY_ACTIONS.STAY_ON_TOP: chkStayOnTop.IsChecked ^= true; break;
@@ -1383,6 +1384,11 @@ namespace EldenRingTool
         private void toggleResists(object sender, RoutedEventArgs e)
         {
             resistsPanel.Visibility = resistsPanel.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void toggleDefenses(object sender, RoutedEventArgs e)
+        {
+            defensesPanel.Visibility = defensesPanel.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void savePosDB(object sender, RoutedEventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -652,23 +652,15 @@ namespace EldenRingTool
             }
             if (defensesPanel.Visibility == Visibility.Visible)
             {
-                var slashDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.SLASH)) * 100);
-                slashDefense = (int)Math.Round(slashDefense / 5.0) * 5;
-                var strikeDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.STRIKE)) * 100);
-                strikeDefense = (int)Math.Round(strikeDefense / 5.0) * 5;
-                var pierceDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.PIERCE)) * 100);
-                pierceDefense = (int)Math.Round(pierceDefense / 5.0) * 5;
-                var standardDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.STANDARD)) * 100);
-                standardDefense = (int)Math.Round(standardDefense / 5.0) * 5;
+                var slashDefense = getRoundedDefense(ERProcess.TargetInfo.SLASH);
+                var strikeDefense = getRoundedDefense(ERProcess.TargetInfo.STRIKE);
+                var pierceDefense = getRoundedDefense(ERProcess.TargetInfo.PIERCE);
+                var standardDefense = getRoundedDefense(ERProcess.TargetInfo.STANDARD);
 
-                var magicDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.MAGIC)) * 100);
-                magicDefense = (int)Math.Round(magicDefense / 5.0) * 5;
-                var fireDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.FIRE)) * 100);
-                fireDefense = (int)Math.Round(fireDefense / 5.0) * 5;
-                var lightningDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.LIGHTNING)) * 100);
-                lightningDefense = (int)Math.Round(lightningDefense / 5.0) * 5;
-                var holyDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.HOLY)) * 100);
-                holyDefense = (int)Math.Round(holyDefense / 5.0) * 5;
+                var magicDefense = getRoundedDefense(ERProcess.TargetInfo.MAGIC);
+                var fireDefense = getRoundedDefense(ERProcess.TargetInfo.FIRE);
+                var lightningDefense = getRoundedDefense(ERProcess.TargetInfo.LIGHTNING);
+                var holyDefense = getRoundedDefense(ERProcess.TargetInfo.HOLY);
 
                 slashVal.Text = slashDefense + "%";
                 strikeVal.Text = strikeDefense + "%";
@@ -680,6 +672,15 @@ namespace EldenRingTool
                 lightningVal.Text = lightningDefense + "%";
                 holyVal.Text = holyDefense + "%";
             }
+        }
+
+        private int getRoundedDefense(ERProcess.TargetInfo type)
+        {
+            // 99.9% of defenses are multiples of 5, this is probably fine for all
+            // Can use below if you want a fidelity of 1%
+            //return (int)Math.Round((1.0 - _process.getTargetDefenses(type)) * 100);
+            
+            return (int)(Math.Round((1.0 - _process.getTargetDefenses(type)) * 100 / 5.0) * 5);
         }
 
         void updateMovement()

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -228,7 +228,27 @@ namespace EldenRingTool
         {
             try
             {
-                var windowInfo = $"{Left} {Top} {isCompact} {resistsPanel.Visibility} {chkSteamInputEnum.IsChecked} {chkSteamAchieve.IsChecked} {chkMuteMusic.IsChecked}";
+                var windowInfo = 
+                    $"{Left} " +
+                    $"{Top} " +
+                    $"{isCompact} " +
+                    $"{chkSteamInputEnum.IsChecked} " +
+                    $"{chkSteamAchieve.IsChecked} " +
+                    $"{chkMuteMusic.IsChecked} " +
+                    $"{PlayerPanel.Visibility} " +
+                    $"{TorrentPanel.Visibility} " +
+                    $"{EnemyPanel.Visibility} " +
+                    $"{MovementPanel.Visibility} " +
+                    $"{TeleportPanel.Visibility} " +
+                    $"{HitboxPanel.Visibility} " +
+                    $"{MeshPanel.Visibility} " +
+                    $"{ViewsPanel.Visibility} " +
+                    $"{MiscPanel.Visibility} " +
+                    $"{QoLPanel.Visibility} " +
+                    $"{hpPoisePanel.Visibility} " +
+                    $"{resistsPanel.Visibility} " +
+                    $"{defensesPanel.Visibility}";
+
                 File.WriteAllText(windowStateFile(), windowInfo);
             }
             catch (Exception ex) { Console.WriteLine(ex.ToString()); }
@@ -244,7 +264,6 @@ namespace EldenRingTool
                 var left = double.Parse(spl[0]);
                 var top = double.Parse(spl[1]);
                 bool compact = bool.Parse(spl[2]);
-                string vis = spl[3];
                 if ((left + Width) > System.Windows.SystemParameters.VirtualScreenWidth || (top + Height) > System.Windows.SystemParameters.VirtualScreenHeight)
                 {
                     Console.WriteLine("Not restoring position, would go off-screen");
@@ -255,13 +274,30 @@ namespace EldenRingTool
                     Top = top;
                 }
                 if (compact) { setCompact(); } //default full
-                if (vis == Visibility.Visible.ToString()) { toggleResists(null, null); } //default hidden
 
-                if (spl.Length >= 7)
+                if (spl.Length >= 6)
                 {
-                    chkSteamInputEnum.IsChecked = bool.Parse(spl[4]);
-                    chkSteamAchieve.IsChecked = bool.Parse(spl[5]);
-                    chkMuteMusic.IsChecked = bool.Parse(spl[6]);
+                    chkSteamInputEnum.IsChecked = bool.Parse(spl[3]);
+                    chkSteamAchieve.IsChecked = bool.Parse(spl[4]);
+                    chkMuteMusic.IsChecked = bool.Parse(spl[5]);
+                }
+                
+                if (spl.Length >= 9)
+                {
+                    RestorePanelVisibility(PlayerPanelControl, PlayerPanel, spl[6]);
+                    RestorePanelVisibility(TorrentPanelControl, TorrentPanel, spl[7]);
+                    RestorePanelVisibility(EnemyPanelControl, EnemyPanel, spl[8]);
+                    RestorePanelVisibility(MovementPanelControl, MovementPanel, spl[9]);
+                    RestorePanelVisibility(TeleportPanelControl, TeleportPanel, spl[10]);
+                    RestorePanelVisibility(HitboxPanelControl, HitboxPanel, spl[11]);
+                    RestorePanelVisibility(MeshPanelControl, MeshPanel, spl[12]);
+                    RestorePanelVisibility(ViewsPanelControl, ViewsPanel, spl[13]);
+                    RestorePanelVisibility(MiscPanelControl, MiscPanel, spl[14]);
+                    RestorePanelVisibility(QoLPanelControl, QoLPanel, spl[15]);
+                    RestorePanelVisibility(hpPoisePanelControl, hpPoisePanel, spl[16]);
+                    RestorePanelVisibility(resistsPanelControl, resistsPanel, spl[17]);
+                    RestorePanelVisibility(defensesPanelControl, defensesPanel, spl[18]);
+
                 }
             }
             catch (Exception ex) { Console.WriteLine(ex.ToString()); }
@@ -885,6 +921,7 @@ namespace EldenRingTool
             }
             _hooked = true;
             targetPanel.Opacity = 1;
+            targetPanel.Visibility = Visibility.Visible;
             targetPanel.IsEnabled = true;
         }
 
@@ -1763,8 +1800,11 @@ namespace EldenRingTool
             {
                 if (element is StackPanel stackPanel && stackPanel.Name != null && stackPanel.Visibility != newVisibility)
                 {
-                    dockPanel_MouseLeftButtonDown(stackPanel, null);
                     stackPanel.Visibility = newVisibility;
+                }
+                if (element is DockPanel dockPanel)
+                {
+                    FixPanelArrows(dockPanel, newVisibility.ToString());
                 }
             }
 
@@ -1773,6 +1813,26 @@ namespace EldenRingTool
             if (sender is Button button)
             {
                 button.Content = newVisibility == Visibility.Visible ? "▼" : "▲";
+            }
+        }
+
+        private void FixPanelArrows(DockPanel panel, string visibility)
+        {
+            var textBox = panel.Children.OfType<TextBlock>().FirstOrDefault();
+            if (textBox != null)
+            {
+                textBox.Text = visibility == Visibility.Visible.ToString() ?
+                                                        textBox.Text.Substring(0, textBox.Text.Length - 1) + "▼" :
+                                                        textBox.Text.Substring(0, textBox.Text.Length - 1) + "▲";
+            }
+        }
+
+        private void RestorePanelVisibility(DockPanel dockPanel, StackPanel stackPanel, string panelVisibility)
+        {
+            if (panelVisibility != Visibility.Visible.ToString())
+            {
+                stackPanel.Visibility = Visibility.Collapsed;
+                FixPanelArrows(dockPanel, panelVisibility);
             }
         }
     }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -615,14 +615,32 @@ namespace EldenRingTool
             if (defensesPanel.Visibility == Visibility.Visible)
             {
                 var slashDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.SLASH)) * 100);
+                slashDefense = (int)Math.Round(slashDefense / 5.0) * 5;
                 var strikeDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.STRIKE)) * 100);
+                strikeDefense = (int)Math.Round(strikeDefense / 5.0) * 5;
                 var pierceDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.PIERCE)) * 100);
+                pierceDefense = (int)Math.Round(pierceDefense / 5.0) * 5;
                 var standardDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.STANDARD)) * 100);
+                standardDefense = (int)Math.Round(standardDefense / 5.0) * 5;
 
                 var magicDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.MAGIC)) * 100);
+                magicDefense = (int)Math.Round(magicDefense / 5.0) * 5;
                 var fireDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.FIRE)) * 100);
+                fireDefense = (int)Math.Round(fireDefense / 5.0) * 5;
                 var lightningDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.LIGHTNING)) * 100);
+                lightningDefense = (int)Math.Round(lightningDefense / 5.0) * 5;
                 var holyDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.HOLY)) * 100);
+                holyDefense = (int)Math.Round(holyDefense / 5.0) * 5;
+
+                slashVal.Text = slashDefense + "%";
+                strikeVal.Text = strikeDefense + "%";
+                pierceVal.Text = pierceDefense + "%";
+                standardVal.Text = standardDefense + "%";
+
+                magicVal.Text = magicDefense + "%";
+                fireVal.Text = fireDefense + "%";
+                lightningVal.Text = fireDefense + "%";
+                holyVal.Text = holyDefense + "%";
             }
         }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1835,11 +1835,18 @@ namespace EldenRingTool
 
         private void RestorePanelVisibility(DockPanel dockPanel, StackPanel stackPanel, string panelVisibility)
         {
-            if (panelVisibility != Visibility.Visible.ToString())
+            if (stackPanel.Visibility.ToString() != panelVisibility)
             {
-                stackPanel.Visibility = Visibility.Collapsed;
-                FixPanelArrows(dockPanel, panelVisibility);
+                if (panelVisibility == Visibility.Visible.ToString())
+                {
+                    stackPanel.Visibility = Visibility.Visible;
+                }
+                else if (panelVisibility == Visibility.Collapsed.ToString())
+                {
+                    stackPanel.Visibility = Visibility.Collapsed;
+                }
             }
+            FixPanelArrows(dockPanel, panelVisibility);
         }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -612,6 +612,18 @@ namespace EldenRingTool
                     statText.Text = $"{statName}: {(int)statAmount} / {(int)statMax}";
                 }
             }
+            if (defensesPanel.Visibility == Visibility.Visible)
+            {
+                var slashDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.SLASH)) * 100);
+                var strikeDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.STRIKE)) * 100);
+                var pierceDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.PIERCE)) * 100);
+                var standardDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.STANDARD)) * 100);
+
+                var magicDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.MAGIC)) * 100);
+                var fireDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.FIRE)) * 100);
+                var lightningDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.LIGHTNING)) * 100);
+                var holyDefense = (int)((1.0 - _process.getTargetDefenses(ERProcess.TargetInfo.HOLY)) * 100);
+            }
         }
 
         void updateMovement()

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -136,6 +136,7 @@ namespace EldenRingTool
         bool _playerNoDeathStateWas = false;
         bool _torNoDeathStateWas = false;
         bool _noClipActive = false;
+        bool panelsCollapsed = false;
 
         static string windowStateFile()
         {
@@ -1721,6 +1722,36 @@ namespace EldenRingTool
                                                             textBox.Text.Substring(0, textBox.Text.Length - 1) + "▼" : 
                                                             textBox.Text.Substring(0, textBox.Text.Length - 1) + "▲";
                 }
+            }
+        }
+
+        private void ToggleCollapse(object sender, RoutedEventArgs e)
+        {
+            var newVisibility = panelsCollapsed ? Visibility.Visible : Visibility.Collapsed;
+
+            foreach (UIElement element in mainPanel.Children)
+            {
+                if (element is StackPanel stackPanel && stackPanel.Name != null)
+                {
+                    // Toggle the visibility of each DockPanel
+                    stackPanel.Visibility = newVisibility;
+                }
+                else if (element is DockPanel dockPanel) {
+                    var textBox = dockPanel.Children.OfType<TextBlock>().FirstOrDefault();
+                    if (textBox != null)
+                    {
+                        textBox.Text = newVisibility == Visibility.Visible ?
+                                                        textBox.Text.Substring(0, textBox.Text.Length - 1) + "▼" :
+                                                        textBox.Text.Substring(0, textBox.Text.Length - 1) + "▲";
+                    }
+                }
+            }
+
+            panelsCollapsed = !panelsCollapsed;
+
+            if (sender is Button button)
+            {
+                button.Content = newVisibility == Visibility.Visible ? "▼" : "▲";
             }
         }
     }


### PR DESCRIPTION
Target Options now has a section for the following resists:
Strike, Slash, Standard, Pierce, Holy, Fire, Lightning, and Magic

UI has been altered to use collapsible sections for target options

Game will now automatically find the ER install location using the steam config files.
It will prioritize running the exe in the local folder in case you're running a version not currently installed on steam. If no local found, finds the installed version