### PR TITLE
Ertool 1.6.1

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -7,11 +7,7 @@ namespace EldenRingTool
     /// </summary>
     public partial class App : Application
     {
-        protected override void OnExit(ExitEventArgs e)
-        {
-            base.OnExit(e);
-            Application.Current.Shutdown();
-        }
+
     }
 
 }

--- a/HotkeySetupWindow.xaml.cs
+++ b/HotkeySetupWindow.xaml.cs
@@ -168,7 +168,7 @@ namespace EldenRingTool
                     MessageBoxButton.OK,
                     MessageBoxImage.Warning
                 );
-                return; 
+                return;
             }
 
             if (OwnerAsMainWindow != null)
@@ -183,12 +183,11 @@ namespace EldenRingTool
 
                     var parts = new List<string>();
 
-                    if ((assignment.HotkeyModifiers & ModifierKeys.Control) != 0) parts.Add("CTRL");
-                    if ((assignment.HotkeyModifiers & ModifierKeys.Alt) != 0) parts.Add("ALT");
-                    if ((assignment.HotkeyModifiers & ModifierKeys.Shift) != 0) parts.Add("SHIFT");
-                    if ((assignment.HotkeyModifiers & ModifierKeys.Windows) != 0) parts.Add("WIN");
+                    var modTokens = GetModifierTokens(assignment.HotkeyModifiers);
+                    if (!string.IsNullOrWhiteSpace(modTokens))
+                        parts.Add(modTokens);
 
-                    parts.Add(assignment.HotkeyKey.ToString().ToUpper());
+                    parts.Add(GetKeyTokenFor(assignment.HotkeyKey));
                     parts.Add(assignment.Action.ToString());
 
                     if (assignment.NeedsParam)
@@ -211,6 +210,42 @@ namespace EldenRingTool
         {
             DialogResult = false;
             Close();
+        }
+
+        private string GetKeyTokenFor(Key key)
+        {
+            foreach (var kvp in KeyMap)
+            {
+                if (kvp.Value == key)
+                    return kvp.Key;
+            }
+            return key.ToString();
+        }
+
+        private string GetModifierTokens(ModifierKeys mk)
+        {
+            var customMods = ModifierKeysToModifiers(mk);
+            var tokens = new List<string>();
+
+            foreach (var kvp in ModMap)
+            {
+                if (kvp.Value != Modifiers.NO_MOD && (customMods & kvp.Value) == kvp.Value)
+                {
+                    tokens.Add(kvp.Key);
+                }
+            }
+
+            return string.Join(" ", tokens);
+        }
+
+        private Modifiers ModifierKeysToModifiers(ModifierKeys mk)
+        {
+            var m = Modifiers.NO_MOD;
+            if ((mk & ModifierKeys.Control) != 0) m |= Modifiers.CTRL;
+            if ((mk & ModifierKeys.Shift) != 0) m |= Modifiers.SHIFT;
+            if ((mk & ModifierKeys.Alt) != 0) m |= Modifiers.ALT;
+            if ((mk & ModifierKeys.Windows) != 0) m |= Modifiers.WIN;
+            return m;
         }
     }
 

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,8 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:EldenRingTool"
         mc:Ignorable="d"
-        Title="ERTool VERSION" Width="345" ResizeMode="NoResize" SizeToContent="Height"
-        >
+        Title="ERTool VERSION" Width="345" ResizeMode="NoResize" SizeToContent="Height">
     <DockPanel Name="dockPanel">
         <StackPanel DockPanel.Dock="Top">
             <StackPanel x:Name="mainPanel">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -368,7 +368,7 @@ namespace EldenRingTool
                 string[] lines;
                 if (!string.IsNullOrEmpty(linesStr))
                 {
-                    lines = linesStr.Split('\r', '\n');
+                    lines = linesStr.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
                 }
                 else
                 {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -49,7 +49,7 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]
 //must include all four parts. parsing a version pads the FRONT with zeroes, in some cases, not the back as you might expect.
 


### PR DESCRIPTION
Fixed issue with incorrect case on some hotkeys.

Added ctrl+click button to re-load hotkeys manually.

Fixed issue of task staying open after closing.
